### PR TITLE
Fix missing requests import

### DIFF
--- a/app/metrics.py
+++ b/app/metrics.py
@@ -1,6 +1,7 @@
 import threading
 import time
 import os
+import requests
 from collections import defaultdict, deque
 from .parser import parse_metrics, should_display_metric, filter_metric, sum_metric, get_metric, eval_formula
 from .config import METRICS_URL, REQUEST_TIMEOUT, UPDATE_INTERVAL, KPI_METRICS_CONFIG, ALL_METRICS, INITIAL_METRICS, SECTIONS


### PR DESCRIPTION
## Summary
- add `requests` import to metrics module

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68815e940424832f842d80487f7a9bb2