### PR TITLE
Remove duplicate history function

### DIFF
--- a/app/metrics.py
+++ b/app/metrics.py
@@ -167,12 +167,6 @@ def get_all_metric_names():
                 names.add(pattern)
     return names
 
-def get_metrics_history():
-    """
-    Возвращает историю метрик
-    """
-    with lock:
-        return {name: list(history) for name, history in metrics_data["history"].items()}
 
 def start_metrics_thread():
     """


### PR DESCRIPTION
## Summary
- consolidate `get_metrics_history` into a single static method
- keep `MetricsService.get_metrics_history` as the implementation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68816933741c832fbec6c906d55120bb