### PR TITLE
Update metric value handling

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -143,7 +143,7 @@ def metric_history(metric_id):
             "data": {
                 "result": [{
                     "metric": {"__name__": metric_id},
-                    "values": [[ts, str(val)] for ts, val in filtered]
+                    "values": [[ts, val] for ts, val in filtered]
                 }]
             }
         }
@@ -167,7 +167,7 @@ def metric_history_api():
         "data": {
             "result": [{
                 "metric": {"__name__": metric},
-                "values": [[d["ts"], str(d["value"])] for d in values]
+                "values": [[ts, val] for ts, val in values]
             }]
         }
     }


### PR DESCRIPTION
## Summary
- return numeric metric values from history APIs
- parse numeric strings on the frontend before formatting

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68877476d290832fa2da3367c85df74c